### PR TITLE
fix(labs/module5): fix broken imports and document streaming event classes

### DIFF
--- a/labs/module5/notebooks/4_streaming.ipynb
+++ b/labs/module5/notebooks/4_streaming.ipynb
@@ -12,8 +12,7 @@
     "## Event Types\n",
     "Our platform streams these events via Server-Sent Events (SSE):\n",
     "- `text_delta`: A chunk of text content\n",
-    "- `text_done`: Text content is complete\n",
-    "- `thinking`: Agent's internal reasoning\n",
+    "- `thinking_delta`: Agent's internal reasoning (chain-of-thought)\n",
     "- `tool_call`: Tool being called\n",
     "- `tool_result`: Result from tool\n",
     "- `error`: Error information\n",
@@ -43,15 +42,39 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Available Event Classes\n",
+    "\n",
+    "All streaming events inherit from `BaseStreamEvent` which provides: `id`, `session_id`, `timestamp`, and `metadata`.\n",
+    "\n",
+    "| Class | Type Key | Purpose | Key Fields |\n",
+    "| --- | --- | --- | --- |\n",
+    "| `StartEvent` | `start` | Signals the stream has begun | — |\n",
+    "| `TextDeltaEvent` | `text_delta` | A chunk of generated text | `text: str` |\n",
+    "| `ThinkingDeltaEvent` | `thinking_delta` | Agent's chain-of-thought reasoning | `thinking: str` |\n",
+    "| `ContentBlockStart` | `content_block_start` | Marks the start of a content block | `content_type`, `content_block` |\n",
+    "| `ContentBlockEnd` | `content_block_end` | Marks the end of a content block | — |\n",
+    "| `ToolCallEvent` | `tool_call` | A complete tool invocation | `tool_call: ToolCall` |\n",
+    "| `ToolCallDeltaEvent` | `tool_call_delta` | Incremental tool call arguments | `arguments_delta: str` |\n",
+    "| `ToolResultEvent` | `tool_result` | Result returned from a tool | `tool_result: ToolResult` |\n",
+    "| `ErrorEvent` | `error` | An error occurred during streaming | `error: str` |\n",
+    "| `DoneEvent` | `done` | Signals the stream is complete | — |\n",
+    "\n",
+    "These are defined in `agentic_platform.core.models.streaming_models` and discriminated by their `type` field for easy deserialization."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from agentic_platform.core.models.streaming_models import ToolCallEvent, ToolResultEvent, ErrorEvent, DoneEvent, TextDeltaEvent, TextDoneEvent, ThinkingEvent\n",
+    "from agentic_platform.core.models.streaming_models import ToolCallEvent, ToolResultEvent, ErrorEvent, DoneEvent, TextDeltaEvent, ThinkingDeltaEvent\n",
     "\n",
     "\n",
-    "TextDoneEvent??"
+    "TextDeltaEvent??"
    ]
   },
   {
@@ -270,7 +293,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "agentic-program-technical-assets",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },

--- a/src/agentic_platform/core/converter/pydanticai_converters.py
+++ b/src/agentic_platform/core/converter/pydanticai_converters.py
@@ -140,7 +140,7 @@ class PydanticAIStreamingEventConverter:
                         }
                     ))
         
-        # Handle final data/output - this should be TextDoneEvent since it's the final complete response
+        # Handle final data/output - emit a final TextDeltaEvent (with is_final metadata) followed by DoneEvent
         elif 'data' in event and event['data'].get('output'):
             events.append(TextDeltaEvent(
                 session_id=session_id,


### PR DESCRIPTION
## Summary
- Fixes `ImportError` in `4_streaming.ipynb` caused by importing non-existent `TextDoneEvent` and `ThinkingEvent`
- Replaces with correct classes: `TextDeltaEvent` and `ThinkingDeltaEvent`
- Adds a reference table documenting all 10 available streaming event classes
- Fixes misleading comment in `pydanticai_converters.py`

Closes #68

## Test plan
- [ ] Open `labs/module5/notebooks/4_streaming.ipynb` and run cell 2 — should import without error
- [ ] Verify the event class reference table renders correctly in the new markdown cell
- [ ] Confirm rest of notebook runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)