### PR TITLE
fix(labs/module2): make setup notebook idempotent for git clone

### DIFF
--- a/labs/module2/notebooks/1_setup.ipynb
+++ b/labs/module2/notebooks/1_setup.ipynb
@@ -47,7 +47,11 @@
     "%%bash\n",
     "mkdir -p ../../data/opensearch-docs\n",
     "cd ../../data/opensearch-docs\n",
-    "git clone https://github.com/opensearch-project/documentation-website.git ."
+    "if [ -d \".git\" ]; then\n",
+    "    echo \"Repository already cloned — skipping.\"\n",
+    "else\n",
+    "    git clone https://github.com/opensearch-project/documentation-website.git .\n",
+    "fi"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Fixes crash when re-running the setup notebook if `opensearch-docs` is already cloned
- Checks for `.git` directory before attempting clone; skips if already present

Closes #72

## Test plan
- [ ] Run cell 2 of `1_setup.ipynb` on first run — clones successfully
- [ ] Run cell 2 again — prints "already cloned" and exits cleanly (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)