### PR TITLE
fix(labs/module5): correct SSM parameter name and add bastion read policy

### DIFF
--- a/deploy/run-migrations-on-bastion.sh
+++ b/deploy/run-migrations-on-bastion.sh
@@ -21,7 +21,7 @@ fi
 # Get the configuration from SSM Parameter Store
 echo "🔍 Retrieving configuration from Parameter Store..."
 CONFIG_JSON=$(aws ssm get-parameter \
-    --name "/agentic-platform/config/dev" \
+    --name "/agentic-platform/config/agentcore-dev" \
     --with-decryption \
     --query 'Parameter.Value' \
     --output text)

--- a/infrastructure/modules/bastion/iam.tf
+++ b/infrastructure/modules/bastion/iam.tf
@@ -237,6 +237,38 @@ resource "aws_iam_role_policy_attachment" "bastion_redis_attachment" {
   role       = aws_iam_role.bastion_role.name
 }
 
+# SSM Parameter Store read policy for bastion
+resource "aws_iam_policy" "ssm_parameter_bastion_policy" {
+  name        = "${var.name_prefix}ssm-parameter-bastion-policy"
+  description = "Policy to allow reading SSM Parameter Store values from bastion"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:GetParametersByPath",
+          "ssm:DescribeParameters"
+        ]
+        Resource = [
+          "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/agentic-platform/*"
+        ]
+      }
+    ]
+  })
+
+  tags = var.common_tags
+}
+
+# Attach the SSM Parameter Store policy to the bastion role
+resource "aws_iam_role_policy_attachment" "bastion_ssm_parameter_attachment" {
+  policy_arn = aws_iam_policy.ssm_parameter_bastion_policy.arn
+  role       = aws_iam_role.bastion_role.name
+}
+
 # ECR policy for the bastion host with least privilege
 resource "aws_iam_policy" "ecr_bastion_policy" {
   name        = "${var.name_prefix}ecr-bastion-policy"

--- a/labs/module5/notebooks/2_llm_gateway.ipynb
+++ b/labs/module5/notebooks/2_llm_gateway.ipynb
@@ -68,7 +68,7 @@
     "\n",
     "# Get the parameter\n",
     "response = ssm_client.get_parameter(\n",
-    "    Name='/agentic-platform/config/dev',\n",
+    "    Name='/agentic-platform/config/agentcore-dev',\n",
     "    WithDecryption=True\n",
     ")\n",
     "\n",
@@ -497,7 +497,7 @@
     "\n",
     "# Get the parameter\n",
     "response = ssm_client.get_parameter(\n",
-    "    Name='/agentic-platform/config/dev',\n",
+    "    Name='/agentic-platform/config/agentcore-dev',\n",
     "    WithDecryption=True\n",
     ")\n",
     "\n",
@@ -512,7 +512,7 @@
     "secret_value: str = secret['SecretString']\n",
     "\n",
     "# Parse the secret value\n",
-    "secret_value_dict: Dict = json.loads(secret_value)\n"
+    "secret_value_dict: Dict = json.loads(secret_value)"
    ]
   },
   {

--- a/labs/module5/notebooks/99999_llm_gateway.ipynb
+++ b/labs/module5/notebooks/99999_llm_gateway.ipynb
@@ -318,7 +318,7 @@
     "\n",
     "# Get the parameter\n",
     "response = ssm_client.get_parameter(\n",
-    "    Name='/agentic-platform/config/dev',\n",
+    "    Name='/agentic-platform/config/agentcore-dev',\n",
     "    WithDecryption=True\n",
     ")\n",
     "\n",
@@ -333,7 +333,7 @@
     "secret_value: str = secret['SecretString']\n",
     "\n",
     "# Parse the secret value\n",
-    "secret_value_dict: Dict = json.loads(secret_value)\n"
+    "secret_value_dict: Dict = json.loads(secret_value)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Fix SSM parameter name from `/agentic-platform/config/dev` → `/agentic-platform/config/agentcore-dev` in notebooks and deploy script
- Add missing SSM Parameter Store read policy (`ssm:GetParameter`, `ssm:GetParameters`, `ssm:GetParametersByPath`, `ssm:DescribeParameters`) to bastion IAM role

Closes #76

## Test plan
- [ ] Run `aws ssm get-parameter --name /agentic-platform/config/agentcore-dev` from bastion after Terraform apply
- [ ] Execute cell 4 in `labs/module5/notebooks/2_llm_gateway.ipynb` on bastion — should return config JSON
- [ ] Run `deploy/run-migrations-on-bastion.sh` on bastion — should retrieve config successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)