### PR TITLE
fix(src): centralize Bedrock model IDs and fix legacy Haiku 3 default

### DIFF
--- a/src/agentic_platform/agent/agentic_chat/agent/agentic_chat_agent.py
+++ b/src/agentic_platform/agent/agentic_chat/agent/agentic_chat_agent.py
@@ -7,6 +7,7 @@ from typing import AsyncGenerator
 from strands import Agent
 from strands_tools import calculator
 from strands.models.litellm import OpenAIModel
+from agentic_platform.core.models.model_config import SONNET_LITELLM_MODEL_ID
 
 from agentic_platform.core.models.api_models import AgenticRequest, AgenticResponse
 from agentic_platform.core.models.memory_models import Message, TextContent
@@ -31,7 +32,7 @@ class StrandsAgenticChatAgent:
         # to use the proxy so it's preferred to use the OpenAIModel type when calling
         # the actual proxy vs. just using the SDK. 
         self.model = OpenAIModel(
-            model_id="anthropic.claude-sonnet-4-20250514-v1:0",
+            model_id=SONNET_LITELLM_MODEL_ID,
             client_args={
                 "api_key": litellm_info.api_key,
                 "base_url": litellm_info.api_endpoint,

--- a/src/agentic_platform/agent/agentic_chat/prompt/agentic_chat_prompt.py
+++ b/src/agentic_platform/agent/agentic_chat/prompt/agentic_chat_prompt.py
@@ -1,4 +1,5 @@
 from agentic_platform.core.models.prompt_models import BasePrompt
+from agentic_platform.core.models.model_config import HAIKU_LITELLM_MODEL_ID
 
 SYSTEM_PROMPT = """
 The assistant is StrandsAgent, an agentic platform assistant.
@@ -57,4 +58,4 @@ StrandsAgent is now being connected with a person.
 class AgenticChatPrompt(BasePrompt):
     system_prompt: str = SYSTEM_PROMPT
     user_prompt: str = "Placeholder, user inputs their own prompt"
-    model_id: str = "us.anthropic.claude-3-haiku-20240307-v1:0"  # Use existing model from proxy
+    model_id: str = HAIKU_LITELLM_MODEL_ID

--- a/src/agentic_platform/agent/agentic_rag/agent/agentic_rag_agent.py
+++ b/src/agentic_platform/agent/agentic_rag/agent/agentic_rag_agent.py
@@ -13,6 +13,7 @@ from agentic_platform.core.models.streaming_models import StreamEvent
 from agentic_platform.core.converter.strands_converters import StrandsStreamingConverter
 from agentic_platform.core.client.llm_gateway.llm_gateway_client import LLMGatewayClient, LiteLLMClientInfo
 from agentic_platform.agent.agentic_rag.prompt.agentic_rag_prompt import AgenticRagPrompt
+from agentic_platform.core.models.model_config import SONNET_LITELLM_MODEL_ID
 from agentic_platform.agent.agentic_rag.tool.kb_tool import search_knowledge_base
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ class StrandsAgenticRagAgent:
         litellm_info: LiteLLMClientInfo = LLMGatewayClient.get_client_info()
 
         self.model = OpenAIModel(
-            model_id="anthropic.claude-sonnet-4-20250514-v1:0",
+            model_id=SONNET_LITELLM_MODEL_ID,
             client_args={
                 "api_key": litellm_info.api_key,
                 "base_url": litellm_info.api_endpoint,

--- a/src/agentic_platform/agent/agentic_rag/prompt/agentic_rag_prompt.py
+++ b/src/agentic_platform/agent/agentic_rag/prompt/agentic_rag_prompt.py
@@ -1,4 +1,5 @@
 from agentic_platform.core.models.prompt_models import BasePrompt
+from agentic_platform.core.models.model_config import SONNET_LITELLM_MODEL_ID
 
 SYSTEM_PROMPT = """
 The assistant is StrandsAgent, an agentic platform assistant with access to a specialized knowledge base.
@@ -67,4 +68,4 @@ If the knowledge base information is relevant, use it to provide a comprehensive
 class AgenticRagPrompt(BasePrompt):
     system_prompt: str = SYSTEM_PROMPT
     user_prompt: str = USER_PROMPT
-    model_id: str = "anthropic.claude-sonnet-4-20250514-v1:0"
+    model_id: str = SONNET_LITELLM_MODEL_ID

--- a/src/agentic_platform/agent/jira_agent/jira_agent.py
+++ b/src/agentic_platform/agent/jira_agent/jira_agent.py
@@ -13,6 +13,7 @@ from agentic_platform.core.models.api_models import AgenticRequest, AgenticRespo
 from agentic_platform.core.models.memory_models import Message, TextContent
 from agentic_platform.core.models.streaming_models import StreamEvent
 from agentic_platform.core.converter.strands_converters import StrandsStreamingConverter
+from agentic_platform.core.models.model_config import SONNET_MODEL_ID
 from agentic_platform.agent.jira_agent.jira_prompt import JiraPrompt
 
 logger = logging.getLogger(__name__)
@@ -26,7 +27,7 @@ class StrandsJiraAgent:
 
         # Use Bedrock directly for local testing
         self.model = BedrockModel(
-            model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+            model_id=SONNET_MODEL_ID,
             region_name=os.getenv("AWS_REGION", "us-east-1")
         )
 

--- a/src/agentic_platform/agent/jira_agent/jira_prompt.py
+++ b/src/agentic_platform/agent/jira_agent/jira_prompt.py
@@ -1,4 +1,5 @@
 from agentic_platform.core.models.prompt_models import BasePrompt
+from agentic_platform.core.models.model_config import SONNET_LITELLM_MODEL_ID
 
 SYSTEM_PROMPT = """
 You are a Jira Assistant, an AI agent specialized in helping users with Jira-related questions and tasks.
@@ -11,4 +12,4 @@ Your knowledge cutoff date is January 2025.
 class JiraPrompt(BasePrompt):
     system_prompt: str = SYSTEM_PROMPT
     user_prompt: str = "Placeholder, user inputs their own prompt"
-    model_id: str = "anthropic.claude-sonnet-4-20250514-v1:0"
+    model_id: str = SONNET_LITELLM_MODEL_ID

--- a/src/agentic_platform/core/models/model_config.py
+++ b/src/agentic_platform/core/models/model_config.py
@@ -1,0 +1,15 @@
+# Centralized Bedrock model IDs — single place to bump when models are deprecated.
+# Agents can import and override these per-agent if needed.
+#
+# Two forms exist because LiteLLM proxy routing uses the non-prefixed model name
+# (e.g. "anthropic.claude-...") while direct Bedrock API calls need the region-
+# prefixed form (e.g. "us.anthropic.claude-...").
+
+# Direct Bedrock API calls (BedrockModel, bedrock-runtime converse)
+HAIKU_MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
+SONNET_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+NOVA_LITE_MODEL_ID = "us.amazon.nova-lite-v1:0"
+
+# LiteLLM proxy model names (must match model_name entries in litellm_config.yaml)
+HAIKU_LITELLM_MODEL_ID = "anthropic.claude-haiku-4-5-20251001-v1:0"
+SONNET_LITELLM_MODEL_ID = "anthropic.claude-sonnet-4-20250514-v1:0"

--- a/src/agentic_platform/core/models/prompt_models.py
+++ b/src/agentic_platform/core/models/prompt_models.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field
 from typing import Dict, Any, List, Optional
 
-HAIKU_MODEL_ID = "us.anthropic.claude-3-haiku-20240307-v1:0"
+from agentic_platform.core.models.model_config import HAIKU_LITELLM_MODEL_ID
 class BasePrompt(BaseModel):
     """
     A streamlined base class for creating prompts with system and user components.
@@ -9,7 +9,7 @@ class BasePrompt(BaseModel):
     system_prompt: str
     user_prompt: str    
     inputs: Dict[str, Any] = Field(default_factory=dict)
-    model_id: str = HAIKU_MODEL_ID
+    model_id: str = HAIKU_LITELLM_MODEL_ID
     hyperparams: Dict[str, Any] = Field(default_factory=lambda: {
         "temperature": 0.5,
         "maxTokens": 1000

--- a/src/agentic_platform/tool/retrieval/retrieval_tool_prompt.py
+++ b/src/agentic_platform/tool/retrieval/retrieval_tool_prompt.py
@@ -1,4 +1,5 @@
 from agentic_platform.core.models.prompt_models import BasePrompt
+from agentic_platform.core.models.model_config import NOVA_LITE_MODEL_ID
 SYSTEM_PROMPT = "You are a RAG bot. You are given a query and context. Your job is to answer the query using ONLY the context provided."
 
 USER_PROMPT = """
@@ -18,6 +19,6 @@ Be very direct and straight forward with your answer. It's returning to an agent
 """    
 
 class RAGPrompt(BasePrompt):
-    model_id: str = "us.amazon.nova-lite-v1:0"
+    model_id: str = NOVA_LITE_MODEL_ID
     system_prompt: str = SYSTEM_PROMPT
     user_prompt: str = USER_PROMPT


### PR DESCRIPTION
## Summary

Closes #51

Replaces hardcoded Bedrock model ID strings across `src/agentic_platform/` with imports from a new centralized `model_config.py`. Fixes the runtime `ResourceNotFoundException` caused by the legacy Haiku 3 default in `BasePrompt`.

**New file:** `src/agentic_platform/core/models/model_config.py`
```python
# Direct Bedrock API calls
HAIKU_MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
SONNET_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
NOVA_LITE_MODEL_ID = "us.amazon.nova-lite-v1:0"

# LiteLLM proxy model names (match litellm_config.yaml)
HAIKU_LITELLM_MODEL_ID = "anthropic.claude-haiku-4-5-20251001-v1:0"
SONNET_LITELLM_MODEL_ID = "anthropic.claude-sonnet-4-20250514-v1:0"
```

**Files updated (8):**
- `core/models/prompt_models.py` — legacy Haiku 3 → `HAIKU_LITELLM_MODEL_ID`
- `agentic_chat/prompt/agentic_chat_prompt.py` — legacy Haiku 3 → `HAIKU_LITELLM_MODEL_ID`
- `agentic_chat/agent/agentic_chat_agent.py` → `SONNET_LITELLM_MODEL_ID`
- `agentic_rag/agent/agentic_rag_agent.py` → `SONNET_LITELLM_MODEL_ID`
- `agentic_rag/prompt/agentic_rag_prompt.py` → `SONNET_LITELLM_MODEL_ID`
- `jira_agent/jira_agent.py` → `SONNET_MODEL_ID` (direct Bedrock)
- `jira_agent/jira_prompt.py` → `SONNET_LITELLM_MODEL_ID`
- `tool/retrieval/retrieval_tool_prompt.py` → `NOVA_LITE_MODEL_ID`

## Intentionally NOT changed

| File | Reason |
|------|--------|
| `infrastructure/modules/ecs/litellmconfig.tf` | Routing table — removing entries breaks deployed services still requesting those models. Requires coordinated rollout. |
| `src/.../litellm_gateway/litellm_config.yaml` | Same — backwards compat for callers that haven't migrated |
| `src/.../strands_glue_athena/agent_service.py` | Pins Sonnet 3.7 for a specific Strands integration; changing without dedicated testing could break that agent |
| `infrastructure/.../knowledgebase/variables.tf` | Embedding model ID (`nova-2-multimodal-embeddings`) — different category, not part of this issue |

## Test plan

- [ ] `python -c "from agentic_platform.core.models.model_config import HAIKU_MODEL_ID, SONNET_MODEL_ID, NOVA_LITE_MODEL_ID, HAIKU_LITELLM_MODEL_ID, SONNET_LITELLM_MODEL_ID"` — imports succeed
- [ ] `python -c "from agentic_platform.core.models.prompt_models import BasePrompt; assert 'haiku-4-5' in BasePrompt().model_id"` — default no longer legacy
- [ ] `python -c "from agentic_platform.agent.agentic_chat.prompt.agentic_chat_prompt import AgenticChatPrompt; assert 'haiku-4-5' in AgenticChatPrompt().model_id"` — chat prompt updated
- [ ] `python -c "from agentic_platform.agent.jira_agent.jira_agent import StrandsJiraAgent"` — import succeeds (agent uses SONNET_MODEL_ID)
- [ ] Grep `src/` for `claude-3-haiku-20240307` — zero hits in .py files

🤖 Generated with [Claude Code](https://claude.com/claude-code)