### PR TITLE
fix: restore local docker compose setup (#89)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,80 @@
+# Local development template. Copy to .env and fill in the placeholders:
+#
+#   cp .env.example .env
+#
+# .env is gitignored. This file must contain NO real secrets.
+#
+# Consumed by docker-compose.yaml (litellm + memory-gateway services) and by
+# host-side tooling that calls load_dotenv(), such as alembic migrations.
+# Local development only -- never deploy these values.
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+# "local" makes auth_middleware skip JWT verification, so no Cognito
+# variables are needed here. It also selects the local branch of
+# DatabaseConfig in core/db/postgres.py.
+ENVIRONMENT=local
+
+# ---------------------------------------------------------------------------
+# LiteLLM gateway (http://localhost:4000)
+# ---------------------------------------------------------------------------
+# Referenced as os.environ/LITELLM_MASTER_KEY in litellm_config.yaml.
+# Generate one in the same "sk-" + 48 alphanumerics format that
+# infrastructure/modules/litellm/litellm-secret.tf produces:
+#
+#   echo "sk-$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 48)"
+#
+LITELLM_MASTER_KEY=sk-REPLACE_WITH_GENERATED_KEY
+
+# Mapped to DATABASE_URL for LiteLLM. The host is the compose service name
+# because LiteLLM connects from inside the compose network. Credentials must
+# match the postgres service in docker-compose.yaml.
+LITELLM_DATABASE_URL=postgresql://dev:dev@postgres:5432/devdb
+
+# What agents use to reach the gateway (read by LLMGatewayClient).
+# LITELLM_KEY should match LITELLM_MASTER_KEY above for local development.
+LITELLM_API_ENDPOINT=http://localhost:4000
+LITELLM_KEY=sk-REPLACE_WITH_GENERATED_KEY
+
+# ---------------------------------------------------------------------------
+# Postgres (pgvector/pgvector:pg16, credentials defined in docker-compose.yaml)
+# ---------------------------------------------------------------------------
+# DatabaseConfig.__post_init__ requires all six of these when ENVIRONMENT=local
+# and will raise on startup if any are missing. Reader and writer point at the
+# same user locally, matching deploy/run-migrations.sh.
+#
+# PG_CONNECTION_URL is localhost here so host-side alembic migrations work.
+# docker-compose.yaml overrides it to postgres:5432 inside the container.
+PG_DATABASE=devdb
+PG_CONNECTION_URL=localhost:5432
+PG_USER=dev
+PG_PASSWORD=dev
+PG_READ_ONLY_USER=dev
+PG_READ_ONLY_PASSWORD=dev
+
+# ---------------------------------------------------------------------------
+# Memory gateway (http://localhost:4001)
+# ---------------------------------------------------------------------------
+# "bedrock_agentcore" routes to AgentCore Memory; any other value uses
+# PGMemoryClient. Unset raises at runtime. See memory-gateway-values.yaml.
+MEMORY_PROVIDER=postgres
+MEMORY_GATEWAY_ENDPOINT=http://localhost:4001
+
+# ---------------------------------------------------------------------------
+# AWS
+# ---------------------------------------------------------------------------
+# ~/.aws is bind-mounted read-only into the containers, so credentials resolve
+# from your local profile. Do not put access keys in this file.
+AWS_DEFAULT_REGION=us-west-2
+AWS_REGION=us-west-2
+# AWS_PROFILE=default
+
+# Optional: only if you authenticate to Bedrock with a bearer token instead of
+# IAM. Several models in litellm_config.yaml reference it.
+# AWS_BEARER_TOKEN_BEDROCK=
+
+# ---------------------------------------------------------------------------
+# Observability (optional)
+# ---------------------------------------------------------------------------
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ git clone https://github.com/aws-samples/sample-agentic-platform.git
 cd sample-agentic-platform
 uv sync
 
+# Create the local environment file used by docker compose
+cp .env.example .env
+
 # Start supporting services (Postgres, Redis, LiteLLM, Memory Gateway)
 make dev:deps
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -65,9 +65,9 @@ services:
   memory-gateway:
     build:
       context: .
-      dockerfile: docker/memory-gateway/Dockerfile
+      dockerfile: src/agentic_platform/service/memory_gateway/Dockerfile
     ports:
-      - "4001:8000"
+      - "4001:8080"
     env_file:
       - .env
     environment:


### PR DESCRIPTION
*Issue #, if available:* 
Fixes #89

*Description of changes:*
The Local Development Quickstart in README.md could not be completed on a clean checkout. `make dev:deps` failed twice for unrelated reasons, and the root .env file it depends on was neither documented nor templated.

Commit ad3a286 moved the memory-gateway Dockerfile into the source tree and deleted the docker/ directory, but left docker-compose.yaml building from the old path. Point it at the current location under src/agentic_platform/service/memory_gateway/.

Correct the memory-gateway port mapping from 4001:8000 to 4001:8080. Its Dockerfile declares EXPOSE 8080 and runs uvicorn on 8080, so the container was unreachable on the published port. The same correction was already applied for Kubernetes in memory-gateway-values.yaml.

Add .env.example covering every variable the Compose services require, with local defaults matching the postgres service credentials, and reference it from the README quickstart. The variables were previously discoverable only by reading DatabaseConfig.__post_init__ and MemoryClient._get_provider, both of which raise at startup when unset.

Verified all four services start and respond: postgres accepts queries, redis runs, litellm returns "I'm alive!" on /health/liveliness, and memory-gateway returns {"status":"healthy"} on /health.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
